### PR TITLE
CASMHMS-5426 Fix image-name for GitHub Actions builds.

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -7,7 +7,7 @@ jobs:
   build_and_release:
     uses: Cray-HPE/hms-build-image-workflows/.github/workflows/build_and_release_image.yaml@v1
     with:
-      image-name: cray-hms-hmcollector
+      image-name: hms-hmcollector
       enable-pr-comment: true
     secrets:
       artifactory-username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}


### PR DESCRIPTION
### Summary and Scope

Fix for previous GitHub Actions PR to continue using the same image name rather than a new one.

### Issues and Related PRs

* Resolves CASMHMS-5426.

### Testing

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

None.